### PR TITLE
chore: fix deprecated github action command set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,5 +55,5 @@ runs:
           curl -L -o $zip_output https://api.sdkman.io/2/broker/download/$candidate/$version/$platform
         fi
 
-        echo "::set-output name=file::$zip_output"
+        echo "file=$zip_output" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

@eddumelendez 
