### PR TITLE
update workflow java versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        version: [ 15.0.1.hs-adpt, 15.0.1.j9-adpt, 15.0.1-amzn, 15.0.1-zulu, 15.0.1.fx-zulu, 15.0.1.fx-librca, 15.0.1-librca, 15.0.1-open, 15.0.1-sapmchn ]
+        version: [ 19.0.1-amzn, 19.0.1-librca, 19.0.1-open, 19.0.1-sapmchn, 19.0.1-tem, 19.0.1-zulu, 19.0.1.fx-librca, 19.0.1.fx-zulu ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Filename of the downloaded archive.
   id: sdkman
   with:
     candidate: java
-    version: 15.0.0-amzn
+    version: 19.0.1-tem
 - uses: actions/setup-java@v1
-    id: setup-java
-    with:
-      java-version: 15.0.0
-      jdkFile: ${{ steps.sdkman.outputs.file }}
+  id: setup-java
+  with:
+    java-version: 19.0.1
+    jdkFile: ${{ steps.sdkman.outputs.file }}
 - run: java --version
 ```


### PR DESCRIPTION
- AdoptOpenJDK is now Eclipse Temurin
- bump java version to 19.0.1
- sort flavors
- update readme